### PR TITLE
docs: set release date for 10.6.0 in CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning 2.0](https://semver.org/spec/v2.0.0.html).
 
-## [10.6.0] - Unreleased
+## [10.6.0] - 2026-09-06
 
 Metadata and packaging release. No changes to the public API.
 


### PR DESCRIPTION
Replaces `Unreleased` with `2026-09-06` in the 10.6.0 entry. The release was published on that date (tag `v10.6.0`).